### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ brew install pipx
 pipx ensurepath
 ```
 
+- Install pivnet-cli
+```
+brew install pivotal/tap/pivnet-cli
+```
+
 To Install latest:
 ```
 pipx install git+https://github.com/atmandhol/tappr.git


### PR DESCRIPTION
Add install pivnet cli step

Using a fresh install of tappr (assuming 0.7.0), ran into an error 

```
tappr tap --verbose install  full 1.4.0 --wait
Running: tanzu package version

v0.11.6

Running: kubectl config use-context REDACTED

Switched to context "REDACTED".

📁 Using k8s context REDACTED
📁 Staging Installation Dir is at /tmp/REDACTED
🔑 Log into Pivnet
Running: pivnet login --api-token='REDACTED'

/bin/sh: pivnet: command not found

💔 Unable to Login. Use --verbose flag for error details.
```

After installing pivnet-cli
```
brew install pivotal/tap/pivnet-cli
```
the command got further.