### PR TITLE
feat: Add subnet flags to GKE cluster creation

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -82,6 +82,8 @@ $ tappr cluster create gke [OPTIONS]
 * `--customize / --no-customize`: Customize the default values  [default: False]
 * `--region TEXT`: GKE cluster region
 * `--num-nodes-per-zone INTEGER`: Number of worker nodes in NodePool per zone
+* `--new-subnet-name TEXT`: Provide a name of new subnet to create that will be used for this GKE cluster
+* `--new-subnet-range INTEGER`: CIDR range routing prefix bits. Should be between 21-24 for a full TAP install  [default: 23]
 * `--help`: Show this message and exit.
 
 #### `tappr cluster create kind`


### PR DESCRIPTION
Fixes #3 

* Add `--new-subnet-name` and `--new-subnet-range` flags for GKE cluster creation.
* Upgrade the gcloud API used for cluster creation from beta `gcloud beta container cluster` to GA `gcloud container cluster`

![Screen Shot 2023-02-20 at 7 50 33 PM](https://user-images.githubusercontent.com/7171846/220220909-cefba4ad-a6f5-4b4b-98af-3e4091bf1b64.png)


![Screen Shot 2023-02-20 at 7 49 51 PM](https://user-images.githubusercontent.com/7171846/220220856-2fb43cc3-33db-4595-ae24-d5bf4fd36e7e.png)
